### PR TITLE
feat : 테스트 결과 페이지 예외처리

### DIFF
--- a/apps/client/src/app/(test-result)/(with-sidebar)/tests/[id]/result/layout.tsx
+++ b/apps/client/src/app/(test-result)/(with-sidebar)/tests/[id]/result/layout.tsx
@@ -1,8 +1,13 @@
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
+import { notFound, redirect } from 'next/navigation';
 
 import { TestResultSidebar } from '@/features/(test-result)/components/TestResultSidebar';
+import {getTestByIdonServer}  from '@/features/(test-detail)/api/server';
 import { Button } from '@/shared/components/ui/button';
+import { ApiError } from '@/shared/constants/api';
+import type { TestDetail } from '@/features/(test-manage)/types';
+
 
 export default async function TestResultLayout({
   children,
@@ -13,16 +18,34 @@ export default async function TestResultLayout({
 }) {
   const { id: testId } = await params;
 
+  let testDetail: TestDetail;
+  try {
+    testDetail = await getTestByIdonServer(testId);
+  } catch (error) {
+    if (error instanceof ApiError) {
+      if (error.statusCode === 404 || error.statusCode === 403 ) {
+        notFound();
+      } else if (error.statusCode === 401) {
+        redirect('/login');
+      }
+    }
+    throw error;
+  }
+
+  if (!testDetail) {
+    return notFound();
+  }
+
   return (
     <div className="flex h-screen flex-col overflow-hidden">
       {/* Top Header */}
-      <header className="flex h-16 shrink-0 items-center justify-start gap-3 border-b bg-white px-6">
+      <header className="flex h-16 shrink-0 items-center justify-start gap-3 border-b bg-background px-6">
         <Button variant="outline" size="icon" asChild>
           <Link href="/workspace">
             <ArrowLeft />
           </Link>
         </Button>
-        <h1 className="text-lg font-semibold">{testId}번 테스트의 결과입니다</h1>
+        <h1 className="text-lg font-semibold">{testDetail.title}</h1>
       </header>
 
       {/* Sidebar and Content */}


### PR DESCRIPTION
## 관련 이슈

close #177 

## 작업 내용

- [x] 404, 403 시 notFound 처리
- [x] 401 시  login 페이지 리다이렉트 처리
- [x] 헤더에서 제목 보여주기

## PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 참고 이미지

## 공유사항 to 리뷰어

레이아웃 컴포넌트에서 미션목록 정보를 사이드바에 `props`로 내려줄수 있을 것 같긴한데 약간 복잡해지기도 해서 나중에 고려해보면 좋을 것 같습니다.

