### PR TITLE
feat : record시 모든 인풋 마스킹

### DIFF
--- a/apps/sdk/src/index.ts
+++ b/apps/sdk/src/index.ts
@@ -121,6 +121,7 @@ async function verifySdkInstallation(testId: string) {
     emit(event) {
       eventQueue.push(event);
     },
+    maskAllInputs: true, // 모든 인풋을 마스킹
   });
 
   // 주기적으로 이벤트 전송


### PR DESCRIPTION
## 관련 이슈

close #issue_number

## 작업 내용

- [x] rrweb event 레코드시 모든 인풋 마스킹 : `recordOptions`에 `maskAllInputs` : `true`, 기존에는 password type input만 마스킹(디폴트 옵션) [추가 옵션 공식문서](https://github.com/rrweb-io/rrweb/blob/master/guide.md#options)

## PR 유형

- [x] 새로운 기능 추가
